### PR TITLE
Fix Docker E2E test dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ test_env/
 
 # Local Python wheels
 vendor/
+!vendor/.gitkeep
 
 # Database
 *.db

--- a/docker-test/.env.example
+++ b/docker-test/.env.example
@@ -29,6 +29,10 @@ JWT_ACCESS_TOKEN_EXPIRE_MINUTES=30
 TEST_ENVIRONMENT=docker
 TESTING=true
 
+# E2E test configuration
+E2E_BASE_URL=http://localhost:8000
+PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
 # Logging configuration
 LOG_LEVEL=DEBUG
 

--- a/docker-test/Dockerfile.test
+++ b/docker-test/Dockerfile.test
@@ -43,11 +43,24 @@ COPY requirements*.txt ./
 COPY requirements-dev.txt ./
 
 # Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install --no-cache-dir -r requirements-dev.txt
+ARG USE_VENDOR=0
+COPY vendor ./vendor
+RUN if [ "$USE_VENDOR" = "1" ] && ls vendor >/dev/null 2>&1; then \
+        pip install --no-index --find-links=vendor -r requirements.txt && \
+        pip install --no-index --find-links=vendor -r requirements-dev.txt; \
+    else \
+        pip install --no-cache-dir -r requirements.txt && \
+        pip install --no-cache-dir -r requirements-dev.txt; \
+    fi
+
+# Pre-cache test dependencies
+RUN pip install --no-cache-dir \
+    playwright==1.40.0 \
+    pytest==7.4.3 \
+    pytest-playwright==0.4.3
 
 # Install Playwright browsers
-RUN pip install playwright && playwright install chromium
+RUN playwright install chromium --with-deps
 
 # Copy application code
 COPY . .

--- a/docker-test/README.md
+++ b/docker-test/README.md
@@ -18,7 +18,16 @@
 cp .env.example .env
 ```
 
-必要に応じて`.env`ファイルを編集してください。
+必要に応じて`.env`ファイルを編集してください。また、オフライン環境でビルドする場合は、
+`vendor/` ディレクトリに事前にダウンロードしたパッケージを配置し、ビルド時に
+`--build-arg USE_VENDOR=1` を指定します。
+
+`.env` には次のE2Eテスト用変数も設定できます。
+
+```env
+E2E_BASE_URL=http://localhost:8000
+PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+```
 
 ### 全テストの実行
 

--- a/docker-test/docker-compose.yml
+++ b/docker-test/docker-compose.yml
@@ -72,6 +72,8 @@ services:
       - JWT_SECRET_KEY=test_jwt_secret_key_for_testing
       - PYTHONPATH=/app
       - TEST_ENVIRONMENT=docker
+      - E2E_BASE_URL=http://localhost:8000
+      - PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
     depends_on:
       test-db:
         condition: service_healthy
@@ -84,7 +86,13 @@ services:
     volumes:
       - ../tests:/app/tests
       - ../src:/app/src
-      - test-results:/app/test-results
+      - ./test-results:/app/test-results
+      - ./playwright-report:/app/playwright-report
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     networks:
       - test-network
     stdin_open: true
@@ -92,7 +100,6 @@ services:
 
 volumes:
   postgres_data:
-  test-results:
 
 networks:
   test-network:

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ addopts =
     -v
     --strict-markers
     --tb=short
+    -n auto --dist loadgroup
 testpaths = tests
 python_files = test_*.py
 python_classes = Test

--- a/run_e2e_tests.py
+++ b/run_e2e_tests.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Simple E2E test runner using pytest and Playwright."""
+
+import os
+import subprocess
+import sys
+
+
+def validate_environment() -> None:
+    """Ensure required environment variables are set."""
+    required_vars = ["E2E_BASE_URL", "PLAYWRIGHT_BROWSERS_PATH"]
+    missing = [var for var in required_vars if not os.getenv(var)]
+    if missing:
+        raise EnvironmentError(
+            f"Missing required environment variables: {', '.join(missing)}"
+        )
+
+
+def main():
+    try:
+        validate_environment()
+    except EnvironmentError as exc:
+        print(exc)
+        sys.exit(1)
+
+    try:
+        subprocess.run([sys.executable, "-m", "pytest", "--version"], check=True)
+    except FileNotFoundError:
+        print("pytest not found. Installing required dependencies...")
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "pytest", "pytest-playwright"],
+            check=True,
+        )
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "tests/e2e",
+        "-v",
+        "--html=playwright-report/report.html",
+        "--self-contained-html",
+    ]
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as exc:
+        print("E2E tests failed", exc)
+        sys.exit(exc.returncode)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- pre-cache test deps in Dockerfile.test and install Playwright browser
- mount host folders for results in docker-test compose
- add healthcheck to test-app service
- add parallel execution option to pytest.ini
- provide `run_e2e_tests.py` with env validation and auto-install of pytest
- add optional offline install support for Docker tests
- document USE_VENDOR build arg and E2E env vars

## Testing
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement)*
- `python run_e2e_tests.py` *(fails: Missing required environment variables)*